### PR TITLE
fix: add automaticallyDeleteInterval.description English localization

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -5,6 +5,7 @@
   "configuration.lineColor.description": "Background color of line with notes (name or HEX)",
   "configuration.rulerColor.description": "Color of the ruler with notes (name or HEX)",
   "configuration.automaticallyDelete.description": "If it set to true, notes that do not correspond to files are automatically deleted.",
+  "configuration.automaticallyDeleteInterval.description": "Time interval (in ms) for checking and auto-deleting notes.",
   "configuration.showGutterIcon.description": "If it set to true, displays the icon on the line where the note exists.",
   "configuration.gutterIconPath.description": "File path of the icon to be displayed"
 }


### PR DESCRIPTION
### Summary of Changes

This PR adds the English localization for the `configuration.automaticallyDeleteInterval.description`. Currently, this localization value is present in the Japanese definitions, but is missing in the English definitions. This causes the user to see the raw template string in the settings for Line Note instead of a descriptive sentence.

### Changes Made
- Added `configuration.automaticallyDeleteInterval.description` to `package.nls.json`. This description explains that this setting defines the time interval (in milliseconds) for checking and automatically deleting notes, providing a better understanding for users.

### Related Issues
- Fixes [tkrkt/linenote#37](https://github.com/tkrkt/linenote/issues/37)
